### PR TITLE
Output requests and limits 

### DIFF
--- a/main.go
+++ b/main.go
@@ -475,12 +475,13 @@ Features detected:
 
 	scalingDown := 0
 	for _, fn := range functions {
+		scalingConfigured := fn.Scaling != nil
 
-		if fn.Scaling.GetZero() == "true" {
+		if scalingConfigured && fn.Scaling.GetZero() == "true" {
 			scalingDown++
 		}
 
-		if fn.Scaling.GetZeroDuration() != "<not set>" {
+		if scalingConfigured && fn.Scaling.GetZeroDuration() != "<not set>" {
 			dur, err := time.ParseDuration(fn.Scaling.GetZeroDuration())
 			if err == nil && dur < time.Minute*5 {
 				fmt.Printf("⚠️ %s scales down after %.2f minutes, this may be too soon, 5 minutes or higher is recommended\n", fn.Name, dur.Minutes())


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Add memory and cpu requests to function outputs. Notify when no memory requests are set for a function.

- Fixes a bug where there was a nil pointer dereference when no scaling configuration is set on a function.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [ ] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))
- [x] My issue has received approval from the maintainers or lead with the `design/approved` label

Closes #2

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Verified with local k3d cluster


![Screenshot 2022-09-06 at 12 02 50](https://user-images.githubusercontent.com/16267532/188608284-2aa1ee38-cb4f-4965-9e77-37eb2e2d0e8c.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
