### PR TITLE
Detect JetStream and warn about NATS Streaming

### DIFF
--- a/main.go
+++ b/main.go
@@ -242,6 +242,7 @@ func main() {
 	directFunctions := false
 	probeFunctions := false
 	clusterRole := false
+	jetstream := false
 
 	for _, dep := range deps.Items {
 
@@ -259,6 +260,7 @@ func main() {
 						}
 					}
 					queueWorkerImage = container.Image
+					jetstream = strings.Contains(queueWorkerImage, "jetstream-queue-worker")
 				}
 			}
 		}
@@ -416,6 +418,10 @@ func main() {
 	if istioDetected {
 		istioIcon = "✅"
 	}
+	jetstreamIcon := "❌"
+	if jetstream {
+		jetstreamIcon = "✅"
+	}
 
 	fmt.Printf(`
 Features detected:
@@ -425,9 +431,10 @@ Features detected:
 - %s Operator mode
 - %s Autoscaler
 - %s Dashboard
+- %s JetStream
 - %s Istio
 
-`, proGatewayIcon, gwHAIcon, operatorIcon, autoscalerIcon, dashboardIcon, istioIcon)
+`, proGatewayIcon, gwHAIcon, operatorIcon, autoscalerIcon, dashboardIcon, jetstreamIcon, istioIcon)
 
 	fmt.Printf(`Other:
 
@@ -469,6 +476,10 @@ Features detected:
 
 	if gatewayReplicas < 3 {
 		fmt.Printf("⚠️ gateway replicas want >= %d but got %d, (not Highly Available (HA))\n", 3, gatewayReplicas)
+	}
+
+	if !jetstream {
+		fmt.Printf("⚠️ NATS Streaming will be deprecated and replaced with NATS JetStream: https://www.openfaas.com/blog/jetstream-for-openfaas/\n")
 	}
 
 	if queueWorkerReplicas < 3 {


### PR DESCRIPTION
Signed-off-by: Han Verstraete (OpenFaaS Ltd) <han@openfaas.com>

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Detect JetStream as feature and print a warning with a reference to the blog if NATS Streaming is detected.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [x] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))
- [x] My issue has received approval from the maintainers or lead with the `design/approved` label

Closes #4 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Verified with local k3d cluster

![Screenshot 2022-09-06 at 12 31 33](https://user-images.githubusercontent.com/16267532/188614172-339750d3-11ee-41b5-a954-ba4a3163eec6.png)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
