### PR TITLE
Detect Pro components via license volume mount

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,10 @@ export DOCKER_BUILDKIT=1
 
 PLATFORM?=linux/arm/v7,linux/arm64,linux/amd64
 
+.PHONY: test
+test:
+	CGO_ENABLED=0 go test $(shell go list ./... | grep -v /vendor/|xargs echo) -cover
+
 .PHONY: publish
 publish:
 	@echo  $(SERVER)/$(OWNER)/$(IMG_NAME):$(TAG) && \

--- a/main.go
+++ b/main.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	v1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
@@ -230,6 +231,7 @@ func main() {
 	controllerTimeout := newTimeout()
 	controllerImage := ""
 	gatewayImage := ""
+	proGateway := false
 
 	queueWorkerImage := ""
 	queueWorkerReplicas := 0
@@ -297,6 +299,7 @@ func main() {
 						}
 					}
 					gatewayImage = container.Image
+					proGateway = isProComponent(container)
 				}
 				if container.Name == "faas-netes" {
 					controllerMode = container.Name
@@ -390,7 +393,7 @@ func main() {
 	}
 
 	proGatewayIcon := "❌"
-	if strings.Contains(gatewayImage, "openfaasltd") {
+	if proGateway {
 		proGatewayIcon = "✅"
 	}
 
@@ -491,7 +494,7 @@ Features detected:
 		fmt.Printf("⚠️ Operator mode is not enabled, OpenFaaS Pro customers should use the OpenFaaS operator\n")
 	}
 
-	if strings.Contains(gatewayImage, "openfaasltd") && len(autoscalerImage) == 0 {
+	if proGateway && len(autoscalerImage) == 0 {
 		fmt.Printf("⚠️ Pro gateway detected, but autoscaler is not enabled\n")
 	}
 
@@ -740,4 +743,22 @@ func getClientset(kubeconfig string) (*kubernetes.Clientset, error) {
 	}
 
 	return clientset, nil
+}
+
+func isProComponent(container corev1.Container) bool {
+	return isProImage(container.Image) || hasLicenseMount(container)
+}
+
+func isProImage(imageName string) bool {
+	return strings.Contains(imageName, "openfaasltd")
+}
+
+func hasLicenseMount(container corev1.Container) bool {
+	for _, mount := range container.VolumeMounts {
+		if mount.Name == "license" {
+			return true
+		}
+	}
+
+	return false
 }

--- a/main_test.go
+++ b/main_test.go
@@ -1,0 +1,21 @@
+package main
+
+import "testing"
+
+func Test_isProImage(t *testing.T) {
+	images := []struct {
+		name string
+		want bool
+	}{
+		{"ghcr.io/openfaas/gateway:0.23.2", false},
+		{"ghcr.io/openfaasltd/gateway:0.2.0", true},
+	}
+
+	for _, image := range images {
+		got := isProImage(image.name)
+		if got != image.want {
+			t.Errorf("Checking: %s returned '%v' while '%v' is expected", image.name, got, image.want)
+		}
+	}
+
+}


### PR DESCRIPTION
Signed-off-by: Han Verstraete (OpenFaaS Ltd) <han@openfaas.com>

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Detect Pro components via the volume mount for the openfaas-license.

First checks the image name for the `openfaasltd` substring. Looks for the license volume mount if this check fails.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [x] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))
- [x] My issue has received approval from the maintainers or lead with the `design/approved` label

Closes #3

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Verified on local k3d clusters

With mirrored Pro gateway image:

![Screenshot 2022-09-06 at 16 18 25](https://user-images.githubusercontent.com/16267532/188659955-3133cf12-e08d-4d63-a94e-c0b2690a0952.png)

With OpenFaaS CE:

![Screenshot 2022-09-06 at 16 12 02](https://user-images.githubusercontent.com/16267532/188660060-eb754611-ad5d-47ed-a1d9-4c3243e28153.png)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
