### PR TITLE
Add warning if root file system not set to read only

### DIFF
--- a/main.go
+++ b/main.go
@@ -519,20 +519,20 @@ Features detected:
 		if len(fn.Timeout.ReadTimeout) == 0 {
 			fmt.Printf("⚠️ %s read_timeout is not set\n", fn.Name)
 		} else if fn.Timeout.GetReadTimeout() > gwUpstreamTimeout {
-			fmt.Printf("⚠️ function %s read_timeout (%s) is greater than gateway.upstream_timeout (%s)\n", fn.Name, fn.Timeout.ReadTimeout, gwUpstreamTimeout)
+			fmt.Printf("⚠️ %s read_timeout (%s) is greater than gateway.upstream_timeout (%s)\n", fn.Name, fn.Timeout.ReadTimeout, gwUpstreamTimeout)
 		}
 
 		if len(fn.Timeout.WriteTimeout) == 0 {
 			fmt.Printf("⚠️ %s write_timeout is not set\n", fn.Name)
 		} else if fn.Timeout.GetWriteTimeout() > gwUpstreamTimeout {
-			fmt.Printf("⚠️ function %s write_timeout (%s) is greater than gateway.upstream_timeout (%s)\n", fn.Name, fn.Timeout.WriteTimeout, gwUpstreamTimeout)
+			fmt.Printf("⚠️ %s write_timeout (%s) is greater than gateway.upstream_timeout (%s)\n", fn.Name, fn.Timeout.WriteTimeout, gwUpstreamTimeout)
 		}
 
 		execTimeout, err := fn.Timeout.GetAdditionalTimeout("exec_timeout")
 		if err != nil {
 			fmt.Printf("⚠️ %s exec_timeout is not set\n", fn.Name)
 		} else if execTimeout > gwUpstreamTimeout {
-			fmt.Printf("⚠️ function %s exec_timeout (%s) is greater than gateway.upstream_timeout (%s)\n", fn.Name, execTimeout, gwUpstreamTimeout)
+			fmt.Printf("⚠️ %s exec_timeout (%s) is greater than gateway.upstream_timeout (%s)\n", fn.Name, execTimeout, gwUpstreamTimeout)
 		}
 
 		if fn.Requests.Memory == "0" {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Add a warning if root file system not set to read only.

Additionally removes the prefix of `function` from the timeout warnings.

Before:
```
"⚠️ function sleep exec_timeout ...."
```

After:
```
"⚠️ sleep exec_timeout ...."
```
 
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [x] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))
- [x] My issue has received approval from the maintainers or lead with the `design/approved` label

Closes #7 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Verified locally on k3d cluster

![Screenshot 2022-09-06 at 17 18 17](https://user-images.githubusercontent.com/16267532/188684477-d3aa48f6-05ac-476c-9a16-d9633c5b4c4c.png)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
