### PR TITLE
Fix check for cluster_role

### DIFF
--- a/main.go
+++ b/main.go
@@ -290,12 +290,6 @@ func main() {
 								log.Fatalf("Error parsing probe_functions: %v, value: %s", err, env.Value)
 							}
 						}
-						if env.Name == "cluster_role" {
-							clusterRole, err = strconv.ParseBool(env.Value)
-							if err != nil {
-								log.Fatalf("Error parsing cluster_role: %v, value: %s", err, env.Value)
-							}
-						}
 						if env.Name == "direct_functions" {
 							directFunctions, err = strconv.ParseBool(env.Value)
 							if err != nil {
@@ -315,7 +309,12 @@ func main() {
 						if env.Name == "write_timeout" {
 							controllerTimeout.WriteTimeout = env.Value
 						}
-
+						if env.Name == "cluster_role" {
+							clusterRole, err = strconv.ParseBool(env.Value)
+							if err != nil {
+								log.Fatalf("Error parsing cluster_role: %v, value: %s", err, env.Value)
+							}
+						}
 					}
 					controllerImage = container.Image
 				}
@@ -328,6 +327,12 @@ func main() {
 							}
 							if env.Name == "write_timeout" {
 								controllerTimeout.WriteTimeout = env.Value
+							}
+						}
+						if env.Name == "cluster_role" {
+							clusterRole, err = strconv.ParseBool(env.Value)
+							if err != nil {
+								log.Fatalf("Error parsing cluster_role: %v, value: %s", err, env.Value)
 							}
 						}
 					}


### PR DESCRIPTION
Signed-off-by: Han Verstraete (OpenFaaS Ltd) <han@openfaas.com>

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Moves check for cluster_role env variable to operator and faas-netes container. 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The checker always reported "Pro autoscaler detected, but cluster_role is disabled - unable to collect CPU/RAM metrics" when the autoscaler is enabled.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested on k3d cluster by deploying OpenFaaS Pro with autoscaler and cluster role enabled and than running the checker. Then repeated the test with the autoscaler enabled but cluster role set to false.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
