### PR TITLE
Warn if dashboard uses auto generated keys

### DIFF
--- a/main.go
+++ b/main.go
@@ -246,6 +246,7 @@ func main() {
 	autoscalerImage := ""
 	autoscalerReplicas := 0
 	dashboardImage := ""
+	dashboardJWTSecret := false
 
 	directFunctions := false
 	probeFunctions := false
@@ -368,6 +369,12 @@ func main() {
 			for _, container := range dep.Spec.Template.Spec.Containers {
 				if container.Name == "dashboard" {
 					dashboardImage = container.Image
+
+					for _, volumeMount := range container.VolumeMounts {
+						if volumeMount.Name == "dashboard-jwt" {
+							dashboardJWTSecret = true
+						}
+					}
 				}
 			}
 		}
@@ -578,6 +585,10 @@ Features detected:
 
 	if controllerSetNonRootUser == false {
 		fmt.Printf("⚠️ Non-root flag is not set for the controller/operator\n")
+	}
+
+	if len(dashboardImage) > 0 && dashboardJWTSecret == false {
+		fmt.Printf("⚠️ Dashboard uses auto generated signing keys: https://docs.openfaas.com/openfaas-pro/dashboard/#create-a-signing-key \n")
 	}
 
 	for _, namespace := range functionNamespaces {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Print a warning when the the OpenFaaS Pro dashboard is using auto generated singing keys.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [x] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))
- [x] My issue has received approval from the maintainers or lead with the `design/approved` label

Closes #20 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Verified the warning is printed only when the dashboard is deployed and no `dashboard-jwt` volume is mounted.

<img width="1002" alt="Screenshot 2023-02-28 at 09 27 32" src="https://user-images.githubusercontent.com/16267532/222454601-cbf8d9ad-3f0a-4a70-b6c5-660c2cba82c8.png">

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
