### PR TITLE
Treat nil value on SecurityContext.ReadOnlyRootFilesystem as false

### DIFF
--- a/main.go
+++ b/main.go
@@ -888,7 +888,10 @@ func readFunctions(deps []v1.Deployment) []Function {
 		function.Limits = lim
 
 		if functionContainer.SecurityContext != nil {
-			function.ReadOnlyRootFilesystem = *functionContainer.SecurityContext.ReadOnlyRootFilesystem
+			if functionContainer.SecurityContext.ReadOnlyRootFilesystem != nil {
+				function.ReadOnlyRootFilesystem = *functionContainer.SecurityContext.ReadOnlyRootFilesystem
+			}
+			function.ReadOnlyRootFilesystem = false
 		}
 
 		functions = append(functions, function)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->

Add nil check when dereferencing SecurityContext.ReadOnlyRootFilesystem and 
treat nil value on SecurityContext.ReadOnlyRootFilesystem as false.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [ ] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))
- [ ] My issue has received approval from the maintainers or lead with the `design/approved` label

 This should fix a nil pointer dereference reported by a customer.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

I was not able to reproduce the nil pointer dereference on any of my cluster but the error reported corresponded with the line that is changed in this PR.

```
OpenFaaS Pro Report
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x11bea09]

goroutine 1 [running]:
main.readFunctions({0xc0004ea000?, 0x11, 0x0?})
/go/src/[github.com/openfaas/checker/main.go:891](http://github.com/openfaas/checker/main.go:891) +0xc49
main.main()
/go/src/[github.com/openfaas/checker/main.go:423](http://github.com/openfaas/checker/main.go:423) +0x21c5
```

Verified the config-checker runs successfully on my clusters.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
